### PR TITLE
PR: fix quote in array of routes names

### DIFF
--- a/src/Oro/Bundle/GoogleTagManagerBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/GoogleTagManagerBundle/Resources/config/services.yml
@@ -60,7 +60,7 @@ services:
         arguments:
             - '@request_stack'
             -
-                oro_frontend_root': 'home'
+                oro_frontend_root: 'home'
                 oro_product_frontend_product_index: 'category'
                 oro_product_frontend_product_view: 'product'
                 oro_shopping_list_frontend_view: 'basket'


### PR DESCRIPTION
Hello,

In route names, the root has a single quotation mark which can cause a missing root match.

Thanks,

Didier